### PR TITLE
Update Changelog for Beta Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 All notable changes to the Pushlytic iOS SDK will be documented in this file.
 
-## [1.0.0] - 2024-02-24
+## [0.1.0] - 2024-02-24
+### Beta Release
+First beta release of Pushlytic iOS SDK! 🎉
+
 ### Added
 - Initial SDK release with core functionality
 - Real-time bidirectional gRPC communication
@@ -9,6 +12,7 @@ All notable changes to the Pushlytic iOS SDK will be documented in this file.
 - Customizable push notifications with dynamic templates
 - Message parsing utilities for type-safe message handling
 - Swift Package Manager support
+- iOS 13.0+ compatibility
 
 ### Developer Experience
 - Complete documentation with usage examples
@@ -16,3 +20,5 @@ All notable changes to the Pushlytic iOS SDK will be documented in this file.
 - Thread-safe message handling
 - Automatic reconnection handling
 - Example app with common implementation patterns
+
+> Note: This is a beta release. Minor version updates (0.x.0) may include breaking changes as we refine the API based on developer feedback.


### PR DESCRIPTION
Update CHANGELOG.md for 0.1.0 beta release

Update version number and messaging to reflect our beta release strategy:

- Change version from 1.0.0 to 0.1.0
- Add "Beta Release" header 
- Include note about potential breaking changes in minor versions
- Maintain comprehensive feature list to showcase robust initial offering
- Add emoji for a bit of fun 🎉

Aligns changelog with our pre-1.0 versioning strategy while maintaining enthusiasm about our feature-rich beta release.