### PR TITLE
feat: add metadata support for initial connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to the Pushlytic iOS SDK will be documented in this file.
 
+## [0.1.2] - 2025-02-08
+### Added
+- **Metadata Support for Initial Connection**
+  - Added ability to include metadata when opening a connection via `openStream(metadata:)`
+
 ## [0.1.1] - 2025-02-02
 ### Changed
 - **Enabled TLS** for all gRPC connections by default

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -440,7 +440,7 @@
 			repositoryURL = "https://github.com/pushlytic/pushlytic-ios-sdk";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.1.1;
+				minimumVersion = 0.1.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Get started with Pushlytic in your iOS app - it's quick and easy!
 ### Swift Package Manager
 1. Open Xcode and go to `File > Add Packages...`
 2. Enter the package URL: `https://github.com/pushlytic/pushlytic-ios-sdk`
-3. Set the dependency rule to **Up to Next Minor Version**, starting at `0.1.1`
+3. Set the dependency rule to **Up to Next Minor Version**, starting at `0.1.2`
 4. Add the package to your desired target
 
 > **Note**: We're rapidly improving Pushlytic! 🚀 During our pre-1.0 phase:

--- a/Sources/Server/Protocols/APIClientProtocol.swift
+++ b/Sources/Server/Protocols/APIClientProtocol.swift
@@ -42,7 +42,7 @@ protocol APIClientProtocol: AnyObject {
     /// - Parameter onStateChange: A closure invoked whenever the message stream state changes.
     /// - Note: This method establishes a persistent connection to the server and handles
     ///   incoming messages or connection events.
-    func openMessageStream(onStateChange: @escaping (MessageStreamState) -> Void)
+    func openMessageStream(metadata: [String: Any]?, onStateChange: @escaping (MessageStreamState) -> Void)
     
     /// Registers a user identifier with the server.
     ///

--- a/Tests/Mocks/MockAPIClient.swift
+++ b/Tests/Mocks/MockAPIClient.swift
@@ -43,8 +43,8 @@ class MockAPIClient: APIClientProtocol {
     
     // Stream state handler
     private(set) var lastStateChangeHandler: ((MessageStreamState) -> Void)?
-    
-    func openMessageStream(onStateChange: @escaping (MessageStreamState) -> Void) {
+
+    func openMessageStream(metadata: [String: Any]?, onStateChange: @escaping (MessageStreamState) -> Void) {
         isMessageStreamOpened = true
         lastStateChangeHandler = onStateChange
     }


### PR DESCRIPTION
- Add metadata parameter to openStream method
- Update sendOpenConnectionMessage to include metadata in initial request